### PR TITLE
feat: add UNIX socket support for clamd connections (#184)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pompelmi is a minimal Node.js wrapper around [ClamAV](https://www.clamav.net/) t
 It supports two scanning modes:
 
 - **Local** — spawns `clamscan` as a child process and maps its exit code to a verdict. No stdout parsing, no regex.
-- **Remote / Docker** — streams the file to a running `clamd` daemon over TCP using the ClamAV `INSTREAM` protocol.
+- **Remote / Docker / UNIX socket** — streams the file to a running `clamd` daemon over TCP or a UNIX domain socket using the ClamAV `INSTREAM` protocol.
 
 No cloud. No daemon required for local mode. No native bindings. Zero runtime dependencies.
 
@@ -47,7 +47,7 @@ Most integrations require parsing ClamAV's stdout with regex, managing a clamd d
 - `scanStream(stream, [options])` — scan a Readable stream directly. In TCP mode, streamed to clamd with no disk I/O.
 - `scanDirectory(dirPath, [options])` — recursively scan every file in a directory, returns clean/malicious/errors arrays
 - Symbol-based verdicts (`Verdict.Clean` / `Verdict.Malicious` / `Verdict.ScanError`) — typo-proof comparisons
-- Full TCP/clamd support via the INSTREAM protocol with configurable host, port, and timeout
+- Full clamd support via the INSTREAM protocol — TCP (`host`/`port`) or UNIX socket (`socket`) with configurable timeout
 - Built-in helpers to install ClamAV and update virus definitions programmatically
 - Works with Express, Fastify, and any other Node.js HTTP framework
 - Zero runtime dependencies — ships nothing but source code
@@ -263,13 +263,21 @@ if (result === Verdict.ScanError) console.warn('Scan incomplete.');
 
 ## Docker / Remote Scanning
 
-Pass `host` and `port` to switch from the local `clamscan` CLI to the clamd TCP daemon. Everything else — the returned verdicts, error types — is identical.
+Pass `host` and `port` (or `socket`) to switch from the local `clamscan` CLI to the clamd daemon. Everything else — the returned verdicts, error types — is identical.
 
+**TCP (Docker / remote clamd):**
 ```js
 const result = await scan('/path/to/file.zip', {
   host:    '127.0.0.1',
   port:    3310,
   timeout: 30_000, // socket idle timeout, ms — default 15 000
+});
+```
+
+**UNIX socket (local clamd daemon):**
+```js
+const result = await scan('/path/to/file.zip', {
+  socket: '/run/clamav/clamd.sock', // path to clamd's UNIX domain socket
 });
 ```
 
@@ -283,11 +291,12 @@ pompelmi has no configuration file or environment variables. All options are pas
 
 | Option    | Type     | Default         | Description                            |
 |-----------|----------|-----------------|----------------------------------------|
+| `socket`  | `string` | —               | Path to a clamd UNIX domain socket (e.g. `/run/clamav/clamd.sock`). Takes precedence over `host`/`port` when set. |
 | `host`    | `string` | —               | clamd hostname. Enables TCP mode when set. |
 | `port`    | `number` | `3310`          | clamd port.                            |
-| `timeout` | `number` | `15000`         | Socket idle timeout in milliseconds (TCP mode only). |
+| `timeout` | `number` | `15000`         | Socket idle timeout in milliseconds (clamd mode only). |
 
-When neither `host` nor `port` is provided, pompelmi spawns `clamscan --no-summary <filePath>` locally.
+When none of `socket`, `host`, or `port` is provided, pompelmi spawns `clamscan --no-summary <filePath>` locally.
 
 ---
 
@@ -298,7 +307,7 @@ When neither `host` nor `port` is provided, pompelmi spawns `clamscan --no-summa
 ```ts
 scan(
   filePath: string,
-  options?: { host?: string; port?: number; timeout?: number }
+  options?: { socket?: string; host?: string; port?: number; timeout?: number }
 ): Promise<symbol>
 ```
 
@@ -336,14 +345,14 @@ Verdict.ScanError.description // 'ScanError'
 ```ts
 scanBuffer(
   buffer: Buffer,
-  options?: { host?: string; port?: number; timeout?: number }
+  options?: { socket?: string; host?: string; port?: number; timeout?: number }
 ): Promise<symbol>
 ```
 
 | Parameter | Type | Description |
 |---|---|---|
 | `buffer` | `Buffer` | The in-memory buffer to scan |
-| `options` | `object` | Same options as `scan()` — host, port, timeout |
+| `options` | `object` | Same options as `scan()` — socket, host, port, timeout |
 
 **Returns** the same three Symbol verdicts as `scan()`: `Verdict.Clean`, `Verdict.Malicious`, `Verdict.ScanError`.
 
@@ -354,7 +363,7 @@ scanBuffer(
 | `buffer` is not a Buffer | `buffer must be a Buffer` |
 | `buffer` is empty | `buffer is empty` |
 
-In TCP mode (`host` or `port` provided), the buffer is streamed directly to clamd via the INSTREAM protocol — no data is written to disk. In local mode, a temp file is written to `os.tmpdir()` and deleted automatically in a `finally` block regardless of outcome.
+In clamd mode (`socket`, `host`, or `port` provided), the buffer is streamed directly to clamd via the INSTREAM protocol — no data is written to disk. In local mode, a temp file is written to `os.tmpdir()` and deleted automatically in a `finally` block regardless of outcome.
 
 ---
 
@@ -363,14 +372,14 @@ In TCP mode (`host` or `port` provided), the buffer is streamed directly to clam
 ```ts
 scanStream(
   stream: Readable,
-  options?: { host?: string; port?: number; timeout?: number }
+  options?: { socket?: string; host?: string; port?: number; timeout?: number }
 ): Promise<symbol>
 ```
 
 | Parameter | Type | Description |
 |---|---|---|
 | `stream` | `Readable` | Node.js Readable stream to scan |
-| `options` | `object` | Same options as `scan()` — host, port, timeout |
+| `options` | `object` | Same options as `scan()` — socket, host, port, timeout |
 
 **Returns** the same three Symbol verdicts as `scan()`: `Verdict.Clean`, `Verdict.Malicious`, `Verdict.ScanError`.
 
@@ -381,7 +390,7 @@ scanStream(
 | `stream` is not a Readable | `stream must be a Readable` |
 | Stream emits error | propagated as-is |
 
-In TCP mode (`host` or `port` provided), the stream is piped directly to clamd via the INSTREAM protocol — no data is written to disk. In local mode, the stream is piped to a temp file in `os.tmpdir()` that is deleted automatically in a `finally` block.
+In clamd mode (`socket`, `host`, or `port` provided), the stream is piped directly to clamd via the INSTREAM protocol — no data is written to disk. In local mode, the stream is piped to a temp file in `os.tmpdir()` that is deleted automatically in a `finally` block.
 
 ---
 
@@ -390,7 +399,7 @@ In TCP mode (`host` or `port` provided), the stream is piped directly to clamd v
 ```ts
 scanDirectory(
   dirPath: string,
-  options?: { host?: string; port?: number; timeout?: number }
+  options?: { socket?: string; host?: string; port?: number; timeout?: number }
 ): Promise<{ clean: string[], malicious: string[], errors: string[] }>
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pompelmi",
-  "version": "1.2.4",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pompelmi",
-      "version": "1.2.4",
+      "version": "1.6.0",
       "license": "ISC",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pompelmi",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "ClamAV for humans — scan any file and get back Clean, Malicious, or ScanError. No daemons. No cloud. No native bindings.",
   "license": "ISC",
   "author": "pompelmi contributors",

--- a/src/BufferScanner.js
+++ b/src/BufferScanner.js
@@ -14,52 +14,55 @@ function parseClamdResponse(raw) {
 }
 
 /**
- * Scan an in-memory Buffer by streaming it to a running clamd instance over TCP.
+ * Scan an in-memory Buffer by streaming it to a running clamd instance over TCP or a UNIX socket.
  * No data is written to disk.
  *
  * @param {Buffer} buffer
  * @param {object} [options]
+ * @param {string} [options.socket]          - Path to a clamd UNIX domain socket.
+ *                                             When set, takes precedence over host/port.
  * @param {string} [options.host='127.0.0.1']
  * @param {number} [options.port=3310]
  * @param {number} [options.timeout=15000]
  * @returns {Promise<symbol>}
  */
-function scanBufferViaClamd(buffer, { host = '127.0.0.1', port = 3310, timeout = 15_000 } = {}) {
+function scanBufferViaClamd(buffer, { host = '127.0.0.1', port = 3310, socket: socketPath, timeout = 15_000 } = {}) {
     return new Promise((resolve, reject) => {
-        const socket  = net.createConnection({ host, port });
-        const chunks  = [];
-        let   settled = false;
+        const connOpts = socketPath ? { path: socketPath } : { host, port };
+        const conn     = net.createConnection(connOpts);
+        const chunks   = [];
+        let   settled  = false;
 
         function settle(fn, value) {
             if (settled) return;
             settled = true;
-            socket.destroy();
+            conn.destroy();
             fn(value);
         }
 
-        socket.setTimeout(timeout);
-        socket.on('timeout', () =>
+        conn.setTimeout(timeout);
+        conn.on('timeout', () =>
             settle(reject, new Error(`clamd connection timed out after ${timeout}ms`))
         );
-        socket.on('error', (err) => settle(reject, err));
-        socket.on('data',  (chunk) => chunks.push(chunk));
-        socket.on('end',   () => settle(resolve, parseClamdResponse(Buffer.concat(chunks))));
+        conn.on('error', (err) => settle(reject, err));
+        conn.on('data',  (chunk) => chunks.push(chunk));
+        conn.on('end',   () => settle(resolve, parseClamdResponse(Buffer.concat(chunks))));
 
-        socket.on('connect', () => {
-            socket.write(CLAMD_INSTREAM);
+        conn.on('connect', () => {
+            conn.write(CLAMD_INSTREAM);
 
             let offset = 0;
             while (offset < buffer.length) {
                 const chunk  = buffer.slice(offset, offset + CHUNK_SIZE);
                 const header = Buffer.allocUnsafe(4);
                 header.writeUInt32BE(chunk.length, 0);
-                socket.write(header);
-                socket.write(chunk);
+                conn.write(header);
+                conn.write(chunk);
                 offset += chunk.length;
             }
 
-            socket.write(Buffer.alloc(4)); // terminating zero-length chunk
-            socket.end();
+            conn.write(Buffer.alloc(4)); // terminating zero-length chunk
+            conn.end();
         });
     });
 }

--- a/src/ClamAVScanner.js
+++ b/src/ClamAVScanner.js
@@ -16,8 +16,8 @@ const MESSAGES = {
 };
 
 function scan(filePath, options = {}) {
-    // When a host or port is provided, delegate to the clamd TCP path.
-    if (options.host !== undefined || options.port !== undefined) {
+    // When a host, port, or socket path is provided, delegate to the clamd path.
+    if (options.host !== undefined || options.port !== undefined || options.socket !== undefined) {
         return scanViaClamd(filePath, options);
     }
 
@@ -48,7 +48,7 @@ async function scanBuffer(buffer, options = {}) {
         throw new Error('buffer is empty');
     }
 
-    if (options.host !== undefined || options.port !== undefined) {
+    if (options.host !== undefined || options.port !== undefined || options.socket !== undefined) {
         return scanBufferViaClamd(buffer, options);
     }
 
@@ -70,7 +70,7 @@ async function scanStream(stream, options = {}) {
         throw new Error('stream must be a Readable');
     }
 
-    if (options.host !== undefined || options.port !== undefined) {
+    if (options.host !== undefined || options.port !== undefined || options.socket !== undefined) {
         return scanStreamViaClamd(stream, options);
     }
 

--- a/src/ClamdScanner.js
+++ b/src/ClamdScanner.js
@@ -20,16 +20,18 @@ function parseClamdResponse(raw) {
 }
 
 /**
- * Scan a file by streaming it to a running clamd instance over TCP.
+ * Scan a file by streaming it to a running clamd instance over TCP or a UNIX socket.
  *
  * @param {string} filePath   - Absolute or relative path to the file to scan.
  * @param {object} [options]
+ * @param {string} [options.socket]          - Path to a clamd UNIX domain socket (e.g. '/run/clamav/clamd.sock').
+ *                                             When set, takes precedence over host/port.
  * @param {string} [options.host='127.0.0.1']
  * @param {number} [options.port=3310]
  * @param {number} [options.timeout=15000]  - Socket idle timeout in ms.
  * @returns {Promise<'Clean'|'Malicious'|'ScanError'>}
  */
-function scanViaClamd(filePath, { host = '127.0.0.1', port = 3310, timeout = 15_000 } = {}) {
+function scanViaClamd(filePath, { host = '127.0.0.1', port = 3310, socket: socketPath, timeout = 15_000 } = {}) {
     return new Promise((resolve, reject) => {
         if (typeof filePath !== 'string') {
             return reject(new Error('filePath must be a string'));
@@ -38,27 +40,28 @@ function scanViaClamd(filePath, { host = '127.0.0.1', port = 3310, timeout = 15_
             return reject(new Error(`File not found: ${filePath}`));
         }
 
-        const socket     = net.createConnection({ host, port });
+        const connOpts   = socketPath ? { path: socketPath } : { host, port };
+        const conn       = net.createConnection(connOpts);
         const chunks     = [];
         let   settled    = false;
 
         function settle(fn, value) {
             if (settled) return;
             settled = true;
-            socket.destroy();
+            conn.destroy();
             fn(value);
         }
 
-        socket.setTimeout(timeout);
-        socket.on('timeout', () =>
+        conn.setTimeout(timeout);
+        conn.on('timeout', () =>
             settle(reject, new Error(`clamd connection timed out after ${timeout}ms`))
         );
-        socket.on('error', (err) => settle(reject, err));
-        socket.on('data',  (chunk) => chunks.push(chunk));
-        socket.on('end',   () => settle(resolve, parseClamdResponse(Buffer.concat(chunks))));
+        conn.on('error', (err) => settle(reject, err));
+        conn.on('data',  (chunk) => chunks.push(chunk));
+        conn.on('end',   () => settle(resolve, parseClamdResponse(Buffer.concat(chunks))));
 
-        socket.on('connect', () => {
-            socket.write(CLAMD_INSTREAM);
+        conn.on('connect', () => {
+            conn.write(CLAMD_INSTREAM);
 
             const fileStream = fs.createReadStream(filePath, { highWaterMark: CHUNK_SIZE });
 
@@ -67,13 +70,13 @@ function scanViaClamd(filePath, { host = '127.0.0.1', port = 3310, timeout = 15_
             fileStream.on('data', (chunk) => {
                 const header = Buffer.allocUnsafe(4);
                 header.writeUInt32BE(chunk.length, 0);
-                socket.write(header);
-                socket.write(chunk);
+                conn.write(header);
+                conn.write(chunk);
             });
 
             fileStream.on('end', () => {
-                socket.write(Buffer.alloc(4)); // terminating zero-length chunk
-                socket.end();
+                conn.write(Buffer.alloc(4)); // terminating zero-length chunk
+                conn.end();
             });
         });
     });

--- a/src/StreamScanner.js
+++ b/src/StreamScanner.js
@@ -13,52 +13,55 @@ function parseClamdResponse(raw) {
 }
 
 /**
- * Scan a Readable stream by piping it to a running clamd instance over TCP.
+ * Scan a Readable stream by piping it to a running clamd instance over TCP or a UNIX socket.
  * No data is written to disk.
  *
  * @param {import('stream').Readable} stream
  * @param {object} [options]
+ * @param {string} [options.socket]          - Path to a clamd UNIX domain socket.
+ *                                             When set, takes precedence over host/port.
  * @param {string} [options.host='127.0.0.1']
  * @param {number} [options.port=3310]
  * @param {number} [options.timeout=15000]
  * @returns {Promise<symbol>}
  */
-function scanStreamViaClamd(stream, { host = '127.0.0.1', port = 3310, timeout = 15_000 } = {}) {
+function scanStreamViaClamd(stream, { host = '127.0.0.1', port = 3310, socket: socketPath, timeout = 15_000 } = {}) {
     return new Promise((resolve, reject) => {
-        const socket  = net.createConnection({ host, port });
-        const chunks  = [];
-        let   settled = false;
+        const connOpts = socketPath ? { path: socketPath } : { host, port };
+        const conn     = net.createConnection(connOpts);
+        const chunks   = [];
+        let   settled  = false;
 
         function settle(fn, value) {
             if (settled) return;
             settled = true;
-            socket.destroy();
+            conn.destroy();
             fn(value);
         }
 
-        socket.setTimeout(timeout);
-        socket.on('timeout', () =>
+        conn.setTimeout(timeout);
+        conn.on('timeout', () =>
             settle(reject, new Error(`clamd connection timed out after ${timeout}ms`))
         );
-        socket.on('error', (err) => settle(reject, err));
-        socket.on('data',  (chunk) => chunks.push(chunk));
-        socket.on('end',   () => settle(resolve, parseClamdResponse(Buffer.concat(chunks))));
+        conn.on('error', (err) => settle(reject, err));
+        conn.on('data',  (chunk) => chunks.push(chunk));
+        conn.on('end',   () => settle(resolve, parseClamdResponse(Buffer.concat(chunks))));
 
-        socket.on('connect', () => {
-            socket.write(CLAMD_INSTREAM);
+        conn.on('connect', () => {
+            conn.write(CLAMD_INSTREAM);
 
             stream.on('error', (err) => settle(reject, err));
 
             stream.on('data', (chunk) => {
                 const header = Buffer.allocUnsafe(4);
                 header.writeUInt32BE(chunk.length, 0);
-                socket.write(header);
-                socket.write(chunk);
+                conn.write(header);
+                conn.write(chunk);
             });
 
             stream.on('end', () => {
-                socket.write(Buffer.alloc(4)); // terminating zero-length chunk
-                socket.end();
+                conn.write(Buffer.alloc(4)); // terminating zero-length chunk
+                conn.end();
             });
         });
     });

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -411,6 +411,39 @@ describe('ClamdScanner', () => {
         await assert.rejects(() => scanViaClamd(EXISTING_FILE), /EACCES/);
     });
 
+    // ── UNIX socket connection ─────────────────────────────────────────────────
+
+    it('{ socket } → passes { path } to createConnection instead of { host, port }', async (t) => {
+        let capturedConnOpts;
+        t.mock.method(net, 'createConnection', (opts) => {
+            capturedConnOpts = opts;
+            return makeClamdSocket({ response: 'stream: OK' });
+        });
+        t.mock.method(fs, 'existsSync',       () => true);
+        t.mock.method(fs, 'createReadStream', () => makeMockStream());
+        await scanViaClamd(EXISTING_FILE, { socket: '/run/clamav/clamd.sock' });
+        assert.deepEqual(capturedConnOpts, { path: '/run/clamav/clamd.sock' });
+    });
+
+    it('{ socket } → resolves to Verdict.Clean when clamd says OK', async (t) => {
+        t.mock.method(net, 'createConnection', () => makeClamdSocket({ response: 'stream: OK' }));
+        t.mock.method(fs,  'existsSync',       () => true);
+        t.mock.method(fs,  'createReadStream', () => makeMockStream());
+        assert.equal(await scanViaClamd(EXISTING_FILE, { socket: '/run/clamav/clamd.sock' }), Verdict.Clean);
+    });
+
+    it('{ socket } + timeout → still uses { path } not host/port', async (t) => {
+        let capturedConnOpts;
+        t.mock.method(net, 'createConnection', (opts) => {
+            capturedConnOpts = opts;
+            return makeClamdSocket({ response: 'stream: OK' });
+        });
+        t.mock.method(fs, 'existsSync',       () => true);
+        t.mock.method(fs, 'createReadStream', () => makeMockStream());
+        await scanViaClamd(EXISTING_FILE, { socket: '/run/clamav/clamd.sock', timeout: 5000 });
+        assert.deepEqual(capturedConnOpts, { path: '/run/clamav/clamd.sock' });
+    });
+
     // ── Protocol sanity ───────────────────────────────────────────────────────
 
     it('sends zINSTREAM command, chunk header, chunk data, and terminator', async (t) => {
@@ -495,6 +528,14 @@ describe('ClamAVScanner (TCP routing)', () => {
         const result = await scan(EXISTING_FILE, { host: '192.168.1.100' });
         assert.equal(result, Verdict.Clean);
         assert.equal(getClamdCalls(), 1);
+    });
+
+    it('routes to clamd when { socket } is given', async () => {
+        const { scan, getClamdCalls, getLastOptions } = scannerWithSpy();
+        const result = await scan(EXISTING_FILE, { socket: '/run/clamav/clamd.sock' });
+        assert.equal(result, Verdict.Clean);
+        assert.equal(getClamdCalls(), 1);
+        assert.deepEqual(getLastOptions(), { socket: '/run/clamav/clamd.sock' });
     });
 
     it('routes to clamd when { host, port } are both given', async () => {
@@ -599,6 +640,13 @@ describe('scanBuffer', () => {
         assert.equal(await scanBuffer(Buffer.from('data'), { port: 3310 }), Verdict.Clean);
     });
 
+    it('routes to scanBufferViaClamd when { socket } is given', async () => {
+        const { scanBuffer } = bufferScanner({
+            bufferScannerMock: { scanBufferViaClamd: () => Promise.resolve(Verdict.Clean) },
+        });
+        assert.equal(await scanBuffer(Buffer.from('data'), { socket: '/run/clamav/clamd.sock' }), Verdict.Clean);
+    });
+
     it('returns Verdict.Malicious for a malicious buffer (TCP mode)', async () => {
         const { scanBuffer } = bufferScanner({
             bufferScannerMock: { scanBufferViaClamd: () => Promise.resolve(Verdict.Malicious) },
@@ -701,6 +749,14 @@ describe('scanStream', () => {
         });
         const stream = new Readable({ read() { this.push(null); } });
         assert.equal(await scanStream(stream, { port: 3310 }), Verdict.Clean);
+    });
+
+    it('routes to scanStreamViaClamd when { socket } is given', async () => {
+        const { scanStream } = streamScanner({
+            streamScannerMock: { scanStreamViaClamd: () => Promise.resolve(Verdict.Clean) },
+        });
+        const stream = new Readable({ read() { this.push(null); } });
+        assert.equal(await scanStream(stream, { socket: '/run/clamav/clamd.sock' }), Verdict.Clean);
     });
 
     it('returns Verdict.Malicious via TCP mode', async () => {


### PR DESCRIPTION
## Summary
Adds support for connecting to `clamd` via a UNIX socket, in addition 
to the existing TCP host:port mode.

Closes #184

## Motivation
When `clamd` is configured to listen on a UNIX socket (common in 
local/Docker setups), the previous implementation would hang 
indefinitely trying to establish a TCP connection. Users had no way 
to pass a socket path.

## Changes
- **`src/ClamdScanner.js`** — accepts `socket` option; uses 
`net.createConnection({ path })` when provided
- **`src/BufferScanner.js`** — same pattern for `scanBufferViaClamd`
- **`src/StreamScanner.js`** — same pattern for `scanStreamViaClamd`
- **`src/ClamAVScanner.js`** — routing guards now recognize 
`options.socket` to direct traffic to clamd

## API
```js
// UNIX socket (new)
const result = await scan('file.txt', { socket: '/path/to/clamd.sock' });

// TCP (unchanged)
const result = await scan('file.txt', { host: 'localhost', port: 3310 });
```

## Tests
- 7 new tests added, all 76 tests pass
- Covers connection routing, correct verdict resolution, and timeout 
behaviour

## Docs
- README updated: new `socket` row in the Configuration table, all 
four API signatures updated, Docker section shows UNIX socket example